### PR TITLE
feat：bugfix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,12 +93,16 @@ export async function activate(context: vscode.ExtensionContext) {
     // 执行配置迁移（如果需要）
     await MigrationService.checkAndMigrate(context);
 
+    // 配置自动保存
+    configureAutoSave();
+
     // 订阅配置变更事件
     context.subscriptions.push(
         configService.onDidChangeConfig(() => {
             // 配置变更时，刷新侧边栏和 CodeLens
             vscode.commands.executeCommand('noveler.refreshView');
             codeLensProvider?.refresh();
+            configureAutoSave();
         })
     );
 
@@ -531,9 +535,6 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('noveler.jumpToReadmeSection', jumpToReadmeSection)
     );
 
-    // 配置自动保存
-    configureAutoSave();
-
     // 监听文档变化，更新字数统计和高亮
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor((editor) => {
@@ -712,7 +713,7 @@ function updateWordCount(editor: vscode.TextEditor | undefined) {
         return;
     }
 
-    // 使用配置服务检��是否显示字数统计（内部已处理配置回退）
+    // 使用配置服务检查是否显示字数统计（内部已处理配置回退）
     if (!configService.shouldShowWordCountInStatusBar()) {
         wordCountStatusBarItem.hide();
         return;

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -107,6 +107,7 @@ export interface NovelConfig {
 export class ConfigService {
     private static instance?: ConfigService;
     private config: NovelConfig = {};
+    private configLoaded: boolean = false;
     private fileWatcher?: vscode.FileSystemWatcher;
     private configLoadPromise?: Promise<void>; // 配置加载的 Promise，避免竞态条件
 
@@ -203,6 +204,7 @@ export class ConfigService {
                 } else {
                     this.config = fullConfig.noveler;
                 }
+                this.configLoaded = true;
 
                 // 触发配置变更事件
                 this._onDidChangeConfig.fire(this.config);
@@ -271,6 +273,7 @@ export class ConfigService {
                 list: []
             }
         };
+        this.configLoaded = false;
     }
 
     private watchConfig() {
@@ -374,6 +377,8 @@ export class ConfigService {
      * @returns true 表示启用自动保存，false 表示禁用，默认为 true
      */
     public shouldAutoSave(): boolean {
+        if (!this.configLoaded)
+            return false;
         return this.config.autoSave?.value !== false;
     }
 


### PR DESCRIPTION
当前项目没有配置文件(novel.jsonc)时，autoSave的值为false，以避免在打开非小说项目时擅自修改项目配置