### PR TITLE
feat(match): 优化高亮逻辑——添加当前位置匹配选择功能并引入 AC 自动机

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chinese-novel-writer",
-  "version": "0.6.8",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chinese-novel-writer",
-      "version": "0.6.8",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
@@ -961,7 +961,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1147,7 +1146,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1645,7 +1643,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3634,7 +3631,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -183,6 +183,11 @@
         "command": "noveler.showPreview",
         "title": "Noveler: 手机阅读预览",
         "icon": "$(device-mobile)"
+      },
+      {
+        "command": "noveler.chooseMatchAtCursor",
+        "title": "Noveler: 选择当前位置关键词匹配",
+        "icon": "$(symbol-misc)"
       }
     ],
     "menus": {
@@ -211,6 +216,11 @@
           "command": "noveler.addSelectedToWhitelist",
           "when": "editorLangId == markdown && editorHasSelection",
           "group": "noveler@5"
+        },
+        {
+          "command": "noveler.chooseMatchAtCursor",
+          "when": "editorLangId == markdown",
+          "group": "noveler@6"
         }
       ],
       "view/item/context": [

--- a/src/commands/commandRegistrar.ts
+++ b/src/commands/commandRegistrar.ts
@@ -47,6 +47,7 @@ import { jumpToReadmeSection } from './jumpToReadme';
 import { handleError, ErrorSeverity } from '../utils/errorHandler';
 import { Logger } from '../utils/logger';
 import { NovelHighlightProvider } from '../providers/highlightProvider';
+import { chooseMatchAtCursor } from './matchSelectionCommand';
 
 /**
  * 命令注册器依赖项
@@ -357,6 +358,16 @@ function registerUtilityCommands(deps: CommandRegistrarDeps): void {
             highlightProvider.reloadDecorations();
             updateHighlights(vscode.window.activeTextEditor);
             Logger.info('高亮配置已重新加载');
+        })
+    );
+
+    // 在冲突位置手动选择匹配项（跨类型：人物名/敏感词，仅影响当前位置）
+    context.subscriptions.push(
+        vscode.commands.registerCommand('noveler.chooseMatchAtCursor', async () => {
+            // extension 激活早期 registerAllCommands 可能传入了占位 null，这里兜底获取真实实例
+            const safeSensitiveService = deps.sensitiveWordService
+                ?? SensitiveWordService.getInstance();
+            await chooseMatchAtCursor(highlightProvider, safeSensitiveService, deps.sensitiveWordDiagnostic);
         })
     );
 

--- a/src/commands/matchSelectionCommand.ts
+++ b/src/commands/matchSelectionCommand.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import { NovelHighlightProvider } from '../providers/highlightProvider';
+import { SensitiveWordService } from '../services/sensitiveWordService';
+import { MatchCandidate, MatchSelectionService } from '../services/matchSelectionService';
+import { SensitiveWordDiagnosticProvider } from '../providers/sensitiveWordDiagnostic';
+
+/**
+ * 在当前位置选择匹配项（可跨类型：人物名 / 敏感词）
+ */
+export async function chooseMatchAtCursor(
+    highlightProvider: NovelHighlightProvider,
+    sensitiveWordService: SensitiveWordService,
+    sensitiveWordDiagnostic?: SensitiveWordDiagnosticProvider | null
+): Promise<void> {
+    try {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.languageId !== 'markdown') {
+            vscode.window.showInformationMessage('请先在 Markdown 文档中使用该命令');
+            return;
+        }
+
+        const offset = editor.document.offsetAt(editor.selection.active);
+        const docUri = editor.document.uri.toString();
+        const selectionService = MatchSelectionService.getInstance();
+
+        // 候选1：敏感词（原始检测，不应用手动筛选，否则候选会被提前过滤掉）
+        const sensitiveCandidates = sensitiveWordService
+            .detect(editor.document, false)
+            .filter(m => m.start <= offset && offset < m.end)
+            .map<MatchCandidate>(m => ({
+                kind: 'sensitive',
+                word: m.word,
+                start: m.start,
+                end: m.end
+            }));
+
+        // 候选2：人物名（来自高亮提供器）
+        const characterCandidates = (await highlightProvider.getCharacterMatchesAtOffset(editor, offset))
+            .map<MatchCandidate>(m => ({
+                kind: 'character',
+                word: m.word,
+                start: m.start,
+                end: m.end
+            }));
+
+        const allCandidates = [...characterCandidates, ...sensitiveCandidates];
+
+        // 即使当前位置没有候选，也要弹出选择框（至少提供“移除该处匹配”）
+        const picked = await vscode.window.showQuickPick(
+            [
+                {
+                    label: '$(close) 移除该处匹配',
+                    description: '仅影响当前位置，清除该位置所有类型匹配',
+                    action: 'remove' as const
+                },
+                ...allCandidates.map(c => ({
+                    label: c.word,
+                    description: `${c.kind === 'sensitive' ? '敏感词' : '人物名'} [${c.start}, ${c.end})`,
+                    action: 'select' as const,
+                    candidate: c
+                }))
+            ],
+            {
+                placeHolder: allCandidates.length > 0
+                    ? '选择当前位置关键词匹配'
+                    : '当前位置未检测到候选，可选择“移除该处匹配”'
+            }
+        );
+
+        if (!picked) return;
+
+        if (picked.action === 'remove') {
+            // 优先按当前位置实际候选覆盖范围移除，避免仅移除单点导致诊断残留
+            const removeStart = allCandidates.length > 0 ? Math.min(...allCandidates.map(c => c.start)) : offset;
+            const removeEnd = allCandidates.length > 0 ? Math.max(...allCandidates.map(c => c.end)) : offset + 1;
+            selectionService.setRemoveInRange(docUri, removeStart, removeEnd);
+        } else {
+            selectionService.setSelection(docUri, offset, picked.candidate);
+        }
+
+        // 刷新高亮与诊断
+        await highlightProvider.updateHighlights(editor);
+        const diagnosticProvider = sensitiveWordDiagnostic ?? SensitiveWordDiagnosticProvider.getInstance();
+        diagnosticProvider?.updateDiagnostics(editor.document);
+
+        if (picked.action === 'remove') {
+            vscode.window.showInformationMessage('已移除该处匹配');
+        } else {
+            vscode.window.showInformationMessage(`已在当前位置采用：${picked.candidate.word}（${picked.candidate.kind === 'sensitive' ? '敏感词' : '人物名'}）`);
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`选择当前位置关键词匹配失败：${message}`);
+    }
+}
+

--- a/src/providers/highlightProvider.ts
+++ b/src/providers/highlightProvider.ts
@@ -8,7 +8,8 @@ import {
 } from '../constants';
 import { Logger } from '../utils/logger';
 import { getFrontmatterEndOffsetForMatching } from '../utils/frontMatterHelper';
-import { SimpleTrieTree } from '../utils/simpleTrieTree';
+import { AhoCorasick } from '../utils/ahoCorasick';
+import { MatchSelectionService } from '../services/matchSelectionService';
 
 /**
  * 小说高亮提供器
@@ -33,15 +34,18 @@ export class NovelHighlightProvider {
     private characterNamesCache: string[] = [];
     private lastCacheUpdate = 0;
 
-    // Trie 树缓存（替代正则）
-    private cachedCharacterTrie: SimpleTrieTree | null = null;
+    // Trie 树缓存（使用 AC 自动机替代 Trie）
+    private cachedCharacterTrie: AhoCorasick | null = null;
     private cachedCharacterNamesCacheKey = '';
+
+    private readonly matchSelectionService: MatchSelectionService;
 
     // 文件系统监视器，用于自动更新人物缓存
     private characterFolderWatcher?: vscode.FileSystemWatcher;
 
     constructor() {
         this.configService = ConfigService.getInstance();
+        this.matchSelectionService = MatchSelectionService.getInstance();
         this.createDecorationTypes();
         this.loadCharacterNames(); // 初始化时加载人物名称
         this.watchCharactersFolder(); // 监视 characters/ 目录变化
@@ -183,8 +187,8 @@ export class NovelHighlightProvider {
         return this.characterNamesCache;
     }
 
-    // 获取或创建人物名称 Trie 树（带缓存）
-    private getCharacterTrie(characterNames: string[]): SimpleTrieTree | null {
+    // 获取或创建人物名称 AC 自动机（带缓存）
+    private getCharacterTrie(characterNames: string[]): AhoCorasick | null {
         if (characterNames.length === 0) {
             return null;
         }
@@ -203,12 +207,12 @@ export class NovelHighlightProvider {
             return this.cachedCharacterTrie;
         }
 
-        // 构建新的 Trie 树并缓存
-        this.cachedCharacterTrie = new SimpleTrieTree();
+        // 构建新的 AC 自动机并缓存
+        this.cachedCharacterTrie = new AhoCorasick();
         this.cachedCharacterTrie.insertBatch(validNames);
         this.cachedCharacterNamesCacheKey = cacheKey;
 
-        Logger.debug(`人物名 Trie 树已构建，共 ${validNames.length} 个名称`);
+        Logger.debug(`人物名 AC 自动机已构建，共 ${validNames.length} 个名称`);
 
         return this.cachedCharacterTrie;
     }
@@ -269,10 +273,12 @@ export class NovelHighlightProvider {
                 htmlCommentRanges.push(new vscode.Range(startPos, endPos));
             }
 
-            // 使用 Trie 树匹配人物名（排除对话、注释和 frontmatter 范围）
+            // 使用 AC 自动机匹配人物名（排除对话、注释和 frontmatter 范围）
             const characterTrie = this.getCharacterTrie(characterNames);
             if (characterTrie) {
                 const matches = characterTrie.search(text);
+                const filteredMatches: Array<{ word: string; start: number; end: number }> = [];
+
                 for (const match of matches) {
                     // 跳过 frontmatter 区域的匹配
                     if (match.start < frontmatterEndOffset) {
@@ -285,8 +291,28 @@ export class NovelHighlightProvider {
 
                     // 排除对话和注释范围
                     if (!this.isRangeInExcludedAreas(range, dialogueRanges, htmlCommentRanges)) {
-                        characterRanges.push(range);
+                        filteredMatches.push(match);
                     }
+                }
+
+                // 先应用手动选择策略，再做默认冲突处理。
+                // 关键：如果先“最长优先”再过滤，会导致用户手选的短词（如“张三”）
+                // 在冲突解析阶段被提前丢弃，后续无法恢复高亮。
+                const selectedMatches = this.matchSelectionService.filterMatches(
+                    editor.document.uri.toString(),
+                    filteredMatches,
+                    'character'
+                );
+
+                // 对未被手选覆盖的位置，仍按默认最长优先处理重叠
+                const resolvedMatches = this.resolveOverlappingCharacterMatches(
+                    selectedMatches
+                );
+
+                for (const resolved of resolvedMatches) {
+                    const startPos = editor.document.positionAt(resolved.start);
+                    const endPos = editor.document.positionAt(resolved.end);
+                    characterRanges.push(new vscode.Range(startPos, endPos));
                 }
             }
 
@@ -296,6 +322,260 @@ export class NovelHighlightProvider {
         } catch (error) {
             Logger.error('更新高亮时发生错误', error);
         }
+    }
+
+    /**
+     * 在光标所在冲突位置手动选择匹配项（仅影响当前位置）
+     */
+    public async chooseCharacterMatchAtCursor(editor?: vscode.TextEditor): Promise<void> {
+        const targetEditor = editor ?? vscode.window.activeTextEditor;
+        if (!targetEditor || targetEditor.document.languageId !== 'markdown') {
+            vscode.window.showInformationMessage('请先在 Markdown 文档中使用该命令');
+            return;
+        }
+
+        const text = targetEditor.document.getText();
+        const cursorOffset = targetEditor.document.offsetAt(targetEditor.selection.active);
+        const frontmatterEndOffset = getFrontmatterEndOffsetForMatching(text);
+
+        // 对话与注释范围
+        const dialogueRanges: vscode.Range[] = [];
+        const htmlCommentRanges: vscode.Range[] = [];
+        let regexMatch: RegExpExecArray | null;
+
+        const dialogueRegex = new RegExp(DIALOGUE_REGEX.source, 'g');
+        while ((regexMatch = dialogueRegex.exec(text)) !== null) {
+            dialogueRanges.push(
+                new vscode.Range(
+                    targetEditor.document.positionAt(regexMatch.index),
+                    targetEditor.document.positionAt(regexMatch.index + regexMatch[0].length)
+                )
+            );
+        }
+
+        const commentRegex = new RegExp(HTML_COMMENT_REGEX.source, 'g');
+        while ((regexMatch = commentRegex.exec(text)) !== null) {
+            htmlCommentRanges.push(
+                new vscode.Range(
+                    targetEditor.document.positionAt(regexMatch.index),
+                    targetEditor.document.positionAt(regexMatch.index + regexMatch[0].length)
+                )
+            );
+        }
+
+        const overlapCluster = await this.getCharacterOverlapClusterAtOffset(targetEditor, cursorOffset, {
+            frontmatterEndOffset,
+            dialogueRanges,
+            htmlCommentRanges,
+            text
+        });
+        if (!overlapCluster || overlapCluster.matches.length < 2) {
+            vscode.window.showInformationMessage('光标位置没有可选择的覆盖匹配项');
+            return;
+        }
+
+        const picked = await vscode.window.showQuickPick(
+            overlapCluster.matches
+                .sort((a, b) => (b.end - b.start) - (a.end - a.start) || a.start - b.start)
+                .map(m => ({
+                    label: m.word,
+                    description: `[${m.start}, ${m.end})`,
+                    detail: targetEditor.document.getText(new vscode.Range(
+                        targetEditor.document.positionAt(m.start),
+                        targetEditor.document.positionAt(m.end)
+                    )),
+                    match: m
+                })),
+            {
+                placeHolder: '选择该冲突位置应采用的人物名匹配（仅影响该位置）'
+            }
+        );
+
+        if (!picked) return;
+
+        this.matchSelectionService.setSelection(
+            targetEditor.document.uri.toString(),
+            cursorOffset,
+            {
+                kind: 'character',
+                word: picked.match.word,
+                start: picked.match.start,
+                end: picked.match.end
+            }
+        );
+
+        await this.updateHighlights(targetEditor);
+        vscode.window.showInformationMessage(`已在当前位置采用匹配：${picked.match.word}`);
+    }
+
+    /**
+     * 获取指定光标位置的人物名冲突簇（供跨类型匹配选择复用）
+     */
+    public async getCharacterMatchesAtOffset(
+        editor: vscode.TextEditor,
+        offset: number
+    ): Promise<Array<{ word: string; start: number; end: number }>> {
+        if (!editor || editor.document.languageId !== 'markdown') {
+            return [];
+        }
+
+        const text = editor.document.getText();
+        const frontmatterEndOffset = getFrontmatterEndOffsetForMatching(text);
+
+        const dialogueRanges: vscode.Range[] = [];
+        const htmlCommentRanges: vscode.Range[] = [];
+        let regexMatch: RegExpExecArray | null;
+
+        const dialogueRegex = new RegExp(DIALOGUE_REGEX.source, 'g');
+        while ((regexMatch = dialogueRegex.exec(text)) !== null) {
+            dialogueRanges.push(
+                new vscode.Range(
+                    editor.document.positionAt(regexMatch.index),
+                    editor.document.positionAt(regexMatch.index + regexMatch[0].length)
+                )
+            );
+        }
+
+        const commentRegex = new RegExp(HTML_COMMENT_REGEX.source, 'g');
+        while ((regexMatch = commentRegex.exec(text)) !== null) {
+            htmlCommentRanges.push(
+                new vscode.Range(
+                    editor.document.positionAt(regexMatch.index),
+                    editor.document.positionAt(regexMatch.index + regexMatch[0].length)
+                )
+            );
+        }
+
+        const overlapCluster = await this.getCharacterOverlapClusterAtOffset(editor, offset, {
+            frontmatterEndOffset,
+            dialogueRanges,
+            htmlCommentRanges,
+            text
+        });
+
+        return overlapCluster?.matches ?? [];
+    }
+
+    private async getCharacterOverlapClusterAtOffset(
+        editor: vscode.TextEditor,
+        offset: number,
+        context: {
+            frontmatterEndOffset: number;
+            dialogueRanges: vscode.Range[];
+            htmlCommentRanges: vscode.Range[];
+            text: string;
+        }
+    ): Promise<{ start: number; end: number; matches: Array<{ word: string; start: number; end: number }> } | null> {
+        const characterNamesFromFiles = await this.getCharacterNames();
+        const characterNamesFromConfig = this.configService.getCharacters();
+        const characterNames = [...new Set([...characterNamesFromFiles, ...characterNamesFromConfig])];
+
+        const characterTrie = this.getCharacterTrie(characterNames);
+        if (!characterTrie) {
+            vscode.window.showInformationMessage('未检测到可用人物名匹配');
+            return null;
+        }
+
+        const matches = characterTrie.search(context.text);
+        const filteredMatches: Array<{ word: string; start: number; end: number }> = [];
+        for (const match of matches) {
+            if (match.start < context.frontmatterEndOffset) continue;
+
+            const range = new vscode.Range(
+                editor.document.positionAt(match.start),
+                editor.document.positionAt(match.end)
+            );
+            if (!this.isRangeInExcludedAreas(range, context.dialogueRanges, context.htmlCommentRanges)) {
+                filteredMatches.push(match);
+            }
+        }
+
+        return this.getOverlapClusterAtOffset(filteredMatches, offset);
+    }
+
+    /**
+     * 解析重叠匹配：默认最长匹配，若用户在该冲突簇手动选择则优先用户选择
+     */
+    private resolveOverlappingCharacterMatches(
+        matches: Array<{ word: string; start: number; end: number }>
+    ): Array<{ word: string; start: number; end: number }> {
+        if (matches.length <= 1) return matches;
+
+        const sorted = [...matches].sort((a, b) => a.start - b.start || (b.end - b.start) - (a.end - a.start));
+        const result: Array<{ word: string; start: number; end: number }> = [];
+
+        let cluster: Array<{ word: string; start: number; end: number }> = [];
+        let clusterStart = -1;
+        let clusterEnd = -1;
+
+        const flushCluster = () => {
+            if (cluster.length === 0) return;
+            if (cluster.length === 1) {
+                result.push(cluster[0]);
+                return;
+            }
+
+            // 默认策略：最长优先，起点更靠前优先
+            const best = [...cluster].sort((a, b) => (b.end - b.start) - (a.end - a.start) || a.start - b.start)[0];
+            result.push(best);
+        };
+
+        for (const m of sorted) {
+            if (cluster.length === 0) {
+                cluster = [m];
+                clusterStart = m.start;
+                clusterEnd = m.end;
+                continue;
+            }
+
+            if (m.start < clusterEnd) {
+                cluster.push(m);
+                clusterStart = Math.min(clusterStart, m.start);
+                clusterEnd = Math.max(clusterEnd, m.end);
+            } else {
+                flushCluster();
+                cluster = [m];
+                clusterStart = m.start;
+                clusterEnd = m.end;
+            }
+        }
+
+        flushCluster();
+        return result;
+    }
+
+    /**
+     * 获取光标所在位置的重叠冲突簇
+     */
+    private getOverlapClusterAtOffset(
+        matches: Array<{ word: string; start: number; end: number }>,
+        offset: number
+    ): { start: number; end: number; matches: Array<{ word: string; start: number; end: number }> } | null {
+        const atPoint = matches.filter(m => m.start <= offset && offset < m.end);
+        if (atPoint.length === 0) return null;
+
+        let clusterStart = Math.min(...atPoint.map(m => m.start));
+        let clusterEnd = Math.max(...atPoint.map(m => m.end));
+
+        let changed = true;
+        while (changed) {
+            changed = false;
+            for (const m of matches) {
+                const overlaps = m.start < clusterEnd && m.end > clusterStart;
+                if (!overlaps) continue;
+
+                const nextStart = Math.min(clusterStart, m.start);
+                const nextEnd = Math.max(clusterEnd, m.end);
+                if (nextStart !== clusterStart || nextEnd !== clusterEnd) {
+                    clusterStart = nextStart;
+                    clusterEnd = nextEnd;
+                    changed = true;
+                }
+            }
+        }
+
+        const clusterMatches = matches.filter(m => m.start < clusterEnd && m.end > clusterStart);
+        return { start: clusterStart, end: clusterEnd, matches: clusterMatches };
     }
 
     /**

--- a/src/providers/sensitiveWordDiagnostic.ts
+++ b/src/providers/sensitiveWordDiagnostic.ts
@@ -8,6 +8,7 @@ import { Logger } from '../utils/logger';
  * 负责在 VSCode 中显示敏感词检测结果
  */
 export class SensitiveWordDiagnosticProvider {
+    private static instance: SensitiveWordDiagnosticProvider | null = null;
     private diagnosticCollection: vscode.DiagnosticCollection;
     private service: SensitiveWordService;
     private debounceTimer: NodeJS.Timeout | null = null;
@@ -18,8 +19,13 @@ export class SensitiveWordDiagnosticProvider {
     private sessionIgnoreList: Map<string, Set<string>> = new Map();
 
     constructor(service: SensitiveWordService) {
+        SensitiveWordDiagnosticProvider.instance = this;
         this.service = service;
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection('noveler-sensitive');
+    }
+
+    public static getInstance(): SensitiveWordDiagnosticProvider | null {
+        return SensitiveWordDiagnosticProvider.instance;
     }
 
     /**

--- a/src/services/matchSelectionService.ts
+++ b/src/services/matchSelectionService.ts
@@ -1,0 +1,143 @@
+import { Logger } from '../utils/logger';
+
+export type MatchKind = 'character' | 'sensitive';
+
+export interface MatchCandidate {
+    kind: MatchKind;
+    word: string;
+    start: number;
+    end: number;
+}
+
+interface ManualSelection extends MatchCandidate {
+    offset: number;
+    updatedAt: number;
+    removedAtOffset?: boolean;
+    removeRangeStart?: number;
+    removeRangeEnd?: number;
+}
+
+/**
+ * 统一匹配选择服务
+ * - 支持跨类型（人物名/敏感词）在同一位置手动选择
+ * - 仅影响所选位置（offset）
+ */
+export class MatchSelectionService {
+    private static instance?: MatchSelectionService;
+
+    // Map<documentUri, Map<offset, selection>>
+    private readonly selections: Map<string, Map<number, ManualSelection>> = new Map();
+
+    public static getInstance(): MatchSelectionService {
+        if (!MatchSelectionService.instance) {
+            MatchSelectionService.instance = new MatchSelectionService();
+        }
+        return MatchSelectionService.instance;
+    }
+
+    public setSelection(documentUri: string, offset: number, candidate: MatchCandidate): void {
+        const docSelections = this.selections.get(documentUri) ?? new Map<number, ManualSelection>();
+
+        // 清理与当前选择冲突的“移除匹配”记录，支持先移除后恢复
+        for (const [key, selection] of docSelections.entries()) {
+            if (!selection.removedAtOffset) {
+                continue;
+            }
+
+            const removeStart = selection.removeRangeStart ?? selection.offset;
+            const removeEnd = selection.removeRangeEnd ?? (selection.offset + 1);
+            const overlaps = candidate.start < removeEnd && candidate.end > removeStart;
+
+            if (overlaps || (candidate.start <= selection.offset && selection.offset < candidate.end)) {
+                docSelections.delete(key);
+            }
+        }
+
+        docSelections.set(offset, {
+            ...candidate,
+            offset,
+            updatedAt: Date.now()
+        });
+        this.selections.set(documentUri, docSelections);
+        Logger.info(`[MatchSelection] 已设置手动匹配选择: ${candidate.kind}:${candidate.word} @${offset}`);
+    }
+
+    public setRemoveAtOffset(documentUri: string, offset: number): void {
+        const docSelections = this.selections.get(documentUri) ?? new Map<number, ManualSelection>();
+        // 使用哨兵值表示“该位置移除所有匹配”
+        docSelections.set(offset, {
+            kind: 'character',
+            word: '__REMOVE__',
+            start: offset,
+            end: offset + 1,
+            offset,
+            updatedAt: Date.now(),
+            removedAtOffset: true
+        });
+        this.selections.set(documentUri, docSelections);
+        Logger.info(`[MatchSelection] 已设置移除该处匹配 @${offset}`);
+    }
+
+    public setRemoveInRange(documentUri: string, start: number, end: number): void {
+        const docSelections = this.selections.get(documentUri) ?? new Map<number, ManualSelection>();
+        const key = start;
+        docSelections.set(key, {
+            kind: 'character',
+            word: '__REMOVE_RANGE__',
+            start,
+            end,
+            offset: start,
+            updatedAt: Date.now(),
+            removedAtOffset: true,
+            removeRangeStart: start,
+            removeRangeEnd: end
+        });
+        this.selections.set(documentUri, docSelections);
+        Logger.info(`[MatchSelection] 已设置移除范围匹配 [${start}, ${end})`);
+    }
+
+    /**
+     * 按“仅影响当前位置”的规则过滤匹配
+     */
+    public filterMatches<T extends { word: string; start: number; end: number }>(
+        documentUri: string,
+        matches: T[],
+        kind: MatchKind
+    ): T[] {
+        const docSelections = this.selections.get(documentUri);
+        if (!docSelections || docSelections.size === 0 || matches.length === 0) {
+            return matches;
+        }
+
+        let result = [...matches];
+
+        for (const selection of docSelections.values()) {
+            const coversOffset = (m: { start: number; end: number }) => m.start <= selection.offset && selection.offset < m.end;
+            const overlapsRange = (m: { start: number; end: number }) => {
+                if (selection.removeRangeStart === undefined || selection.removeRangeEnd === undefined) {
+                    return false;
+                }
+                return m.start < selection.removeRangeEnd && m.end > selection.removeRangeStart;
+            };
+
+            if (selection.removedAtOffset) {
+                result = result.filter(m => !(coversOffset(m) || overlapsRange(m)));
+                continue;
+            }
+
+            if (selection.kind === kind) {
+                // 同类型：当前位置只保留用户明确选中的那一个
+                result = result.filter(m => {
+                    if (!coversOffset(m)) return true;
+                    return m.word === selection.word && m.start === selection.start && m.end === selection.end;
+                });
+            } else {
+                // 跨类型：当前位置屏蔽本类型匹配
+                result = result.filter(m => !coversOffset(m));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/src/services/sensitiveWordService.ts
+++ b/src/services/sensitiveWordService.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as jsoncParser from 'jsonc-parser';
-import { TrieTree } from '../utils/trieTree';
+import { AhoCorasickLevel } from '../utils/ahoCorasickLevel';
 import {
     SensitiveWordConfig,
     SensitiveLevel,
@@ -13,6 +13,7 @@ import {
 import { Logger } from '../utils/logger';
 import { ConfigService } from './configService';
 import { extractContentWithoutFrontmatterForMatching } from '../utils/frontMatterHelper';
+import { MatchSelectionService } from './matchSelectionService';
 
 /**
  * 敏感词检测服务
@@ -26,13 +27,16 @@ import { extractContentWithoutFrontmatterForMatching } from '../utils/frontMatte
  */
 export class SensitiveWordService {
     private static instance: SensitiveWordService | null = null;
-    private trie: TrieTree = new TrieTree();
+    private trie: AhoCorasickLevel = new AhoCorasickLevel();
     private whitelist: Set<string> = new Set();
     private config!: SensitiveWordConfig;
     private context!: vscode.ExtensionContext;
+    private readonly matchSelectionService: MatchSelectionService;
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    private constructor() {}
+    private constructor() {
+        this.matchSelectionService = MatchSelectionService.getInstance();
+    }
 
     /**
      * 初始化服务（单例）
@@ -93,6 +97,9 @@ export class SensitiveWordService {
             if (this.config.customWords?.enabled) {
                 await this.loadCustomLibrary();
             }
+
+            // 构建 AC 自动机
+            this.trie.build();
 
             Logger.info(`敏感词检测服务初始化完成，共加载 ${this.trie.getWordCount()} 个敏感词`);
         } catch (error) {
@@ -383,7 +390,7 @@ export class SensitiveWordService {
      * @param document VSCode 文档
      * @returns 匹配结果数组
      */
-    public detect(document: vscode.TextDocument): SensitiveMatch[] {
+    public detect(document: vscode.TextDocument, applyManualSelection = true): SensitiveMatch[] {
         if (!this.config.enabled || document.languageId !== 'markdown') {
             return [];
         }
@@ -400,7 +407,7 @@ export class SensitiveWordService {
             return [];
         }
 
-        // 使用 Trie 树检测
+        // 使用 AC 自动机检测
         let matches = this.trie.search(text);
 
         // 过滤白名单
@@ -417,6 +424,15 @@ export class SensitiveWordService {
         matches.forEach(m => {
             m.inWhitelist = this.whitelist.has(m.word);
         });
+
+        // 应用跨类型统一选择策略（仅影响当前位置）
+        if (applyManualSelection) {
+            matches = this.matchSelectionService.filterMatches(
+                document.uri.toString(),
+                matches,
+                'sensitive'
+            );
+        }
 
         return matches;
     }

--- a/src/utils/ahoCorasick.ts
+++ b/src/utils/ahoCorasick.ts
@@ -1,0 +1,163 @@
+/**
+ * Aho-Corasick 自动机
+ * 用于高效的多模式字符串匹配，时间复杂度 O(n + z)
+ * n = 文本长度，z = 匹配总数
+ *
+ * @example
+ * ```typescript
+ * const ac = new AhoCorasick();
+ * ac.insertBatch(['张三', '李四', '王五']);
+ * const matches = ac.search('张三丰和李四在聊天');
+ * // [{ word: '张三', start: 0, end: 2 }, { word: '李四', start: 3, end: 5 }]
+ * ```
+ */
+
+/**
+ * 匹配结果
+ */
+export interface ACMatch {
+    word: string;
+    start: number;
+    end: number;
+}
+
+interface ACState {
+    next: Map<string, number>;
+    fail: number;
+    output: number;
+    word?: string;
+}
+
+export class AhoCorasick {
+    private states: ACState[] = [];
+    private patternCount = 0;
+
+    constructor() {
+        this.states.push({
+            next: new Map(),
+            fail: 0,
+            output: 0
+        });
+    }
+
+    /**
+     * 插入单个模式
+     */
+    insert(word: string): void {
+        if (!word || word.length === 0) return;
+
+        let state = 0;
+        for (const ch of word) {
+            const chStr = ch;
+            let nextState = this.states[state].next.get(chStr);
+            if (nextState === undefined) {
+                nextState = this.states.length;
+                this.states.push({
+                    next: new Map(),
+                    fail: 0,
+                    output: 0
+                });
+                this.states[state].next.set(chStr, nextState);
+            }
+            state = nextState;
+        }
+
+        if (!this.states[state].word) {
+            this.patternCount++;
+        }
+        this.states[state].word = word;
+    }
+
+    /**
+     * 批量插入模式并构建失败链接
+     */
+    insertBatch(words: string[]): void {
+        for (const word of words) {
+            this.insert(word);
+        }
+        this.build();
+    }
+
+    /**
+     * 构建失败链接
+     */
+    private build(): void {
+        const queue: number[] = [];
+        
+        // 初始化根节点的所有直接子节点的失败链接
+        for (const [, nextState] of this.states[0].next) {
+            this.states[nextState].fail = 0;
+            queue.push(nextState);
+        }
+
+        // BFS
+        while (queue.length > 0) {
+            const current = queue.shift()!;
+            
+            for (const [ch, nextState] of this.states[current].next) {
+                queue.push(nextState);
+                
+                // 计算失败链接
+                let fail = this.states[current].fail;
+                while (fail > 0 && !this.states[fail].next.has(ch)) {
+                    fail = this.states[fail].fail;
+                }
+                
+                const nextFail = this.states[fail].next.get(ch);
+                this.states[nextState].fail = nextFail !== undefined ? nextFail : 0;
+                
+                // 设置输出链接
+                if (this.states[nextState].word) {
+                    this.states[nextState].output = nextState;
+                } else if (this.states[fail].word) {
+                    this.states[nextState].output = fail;
+                } else {
+                    this.states[nextState].output = this.states[fail].output;
+                }
+            }
+        }
+    }
+
+    /**
+     * 搜索文本
+     */
+    search(text: string): ACMatch[] {
+        if (!text || text.length === 0) return [];
+        
+        const results: ACMatch[] = [];
+        let state = 0;
+        
+        for (let i = 0; i < text.length; i++) {
+            const ch = text[i];
+            
+            // 找到下一个有效状态
+            while (state > 0 && !this.states[state].next.has(ch)) {
+                state = this.states[state].fail;
+            }
+            
+            const nextState = this.states[state].next.get(ch);
+            state = nextState !== undefined ? nextState : 0;
+            
+            // 输出所有匹配
+            let outputState = state;
+            while (outputState > 0) {
+                const s = this.states[outputState];
+                if (s.word) {
+                    results.push({
+                        word: s.word,
+                        start: i - s.word.length + 1,
+                        end: i + 1
+                    });
+                }
+                if (s.output === outputState) break;
+                outputState = this.states[outputState].output;
+            }
+        }
+        
+        return results;
+    }
+
+    getPatternCount(): number {
+        return this.patternCount;
+    }
+}

--- a/src/utils/ahoCorasickLevel.ts
+++ b/src/utils/ahoCorasickLevel.ts
@@ -1,0 +1,160 @@
+/**
+ * Aho-Corasick 自动机（支持敏感级别）
+ * 用于高效的敏感词检测，时间复杂度 O(n + z)
+ * n = 文本长度，z = 匹配总数
+ */
+
+import { SensitiveLevel, SensitiveMatch } from '../types/sensitiveWord';
+
+interface ACState {
+    next: Map<string, number>;
+    fail: number;
+    output: number;
+    word?: string;
+    level?: SensitiveLevel;
+}
+
+export class AhoCorasickLevel {
+    private states: ACState[] = [];
+    private wordCount = 0;
+
+    constructor() {
+        this.states.push({
+            next: new Map(),
+            fail: 0,
+            output: 0
+        });
+    }
+
+    /**
+     * 插入单个词
+     */
+    insert(word: string, level: SensitiveLevel): void {
+        if (!word || word.length === 0) return;
+
+        let state = 0;
+        for (const ch of word) {
+            const chStr = ch;
+            let nextState = this.states[state].next.get(chStr);
+            if (nextState === undefined) {
+                nextState = this.states.length;
+                this.states.push({
+                    next: new Map(),
+                    fail: 0,
+                    output: 0
+                });
+                this.states[state].next.set(chStr, nextState);
+            }
+            state = nextState;
+        }
+
+        if (!this.states[state].word) {
+            this.wordCount++;
+        }
+        this.states[state].word = word;
+        this.states[state].level = level;
+    }
+
+    /**
+     * 批量插入词汇
+     */
+    insertBatch(words: string[], level: SensitiveLevel): void {
+        for (const word of words) {
+            this.insert(word, level);
+        }
+    }
+
+    /**
+     * 批量插入完成后构建失败链接
+     */
+    build(): void {
+        const queue: number[] = [];
+        
+        // 初始化根节点的所有直接子节点的失败链接
+        for (const [, nextState] of this.states[0].next) {
+            this.states[nextState].fail = 0;
+            queue.push(nextState);
+        }
+
+        // BFS
+        while (queue.length > 0) {
+            const current = queue.shift()!;
+            
+            for (const [ch, nextState] of this.states[current].next) {
+                queue.push(nextState);
+                
+                // 计算失败链接
+                let fail = this.states[current].fail;
+                while (fail > 0 && !this.states[fail].next.has(ch)) {
+                    fail = this.states[fail].fail;
+                }
+                
+                const nextFail = this.states[fail].next.get(ch);
+                this.states[nextState].fail = nextFail !== undefined ? nextFail : 0;
+                
+                // 设置输出链接
+                if (this.states[nextState].word) {
+                    this.states[nextState].output = nextState;
+                } else if (this.states[fail].word) {
+                    this.states[nextState].output = fail;
+                } else {
+                    this.states[nextState].output = this.states[fail].output;
+                }
+            }
+        }
+    }
+
+    /**
+     * 搜索敏感词
+     */
+    search(text: string): SensitiveMatch[] {
+        if (!text || text.length === 0) return [];
+        
+        const results: SensitiveMatch[] = [];
+        let state = 0;
+        
+        for (let i = 0; i < text.length; i++) {
+            const ch = text[i];
+            
+            // 找到下一个有效状态
+            while (state > 0 && !this.states[state].next.has(ch)) {
+                state = this.states[state].fail;
+            }
+            
+            const nextState = this.states[state].next.get(ch);
+            state = nextState !== undefined ? nextState : 0;
+            
+            // 输出所有匹配
+            let outputState = state;
+            while (outputState > 0) {
+                const s = this.states[outputState];
+                if (s.word) {
+                    results.push({
+                        word: s.word,
+                        start: i - s.word.length + 1,
+                        end: i + 1,
+                        level: s.level || 'high',
+                        inWhitelist: false
+                    });
+                }
+                if (s.output === outputState) break;
+                outputState = this.states[outputState].output;
+            }
+        }
+        
+        return results;
+    }
+
+    getWordCount(): number {
+        return this.wordCount;
+    }
+
+    clear(): void {
+        this.states = [{
+            next: new Map(),
+            fail: 0,
+            output: 0
+        }];
+        this.wordCount = 0;
+    }
+}


### PR DESCRIPTION
变更内容
新增命令 noveler.chooseMatchAtCursor，并在编辑器右键菜单中加入入口（Markdown 场景）。
新增统一选择服务 MatchSelectionService，支持：
在当前位置手动选择“人物名”或“敏感词”匹配；
仅对当前冲突位置生效；
可移除当前位置（或冲突范围）匹配。
人物名匹配从原有 Trie 方案升级为 AhoCorasick，并在 NovelHighlightProvider.updateHighlights() 中加入重叠冲突处理与手动选择过滤。
敏感词匹配升级为 AhoCorasickLevel，在 SensitiveWordService.detect() 中支持按手动选择结果过滤。
为诊断刷新增加实例访问能力 SensitiveWordDiagnosticProvider.getInstance()，确保命令执行后可立即刷新诊断。
解决的问题
解决“同一位置多种匹配冲突（人物名/敏感词、长短词重叠）时无法精确控制展示结果”的问题。
提供“位置级、可解释、可恢复”的人工干预能力，降低误报与误高亮。
引入 AC 自动机后，多模式匹配性能与可扩展性更好，适合词库规模增长。


What’s changed
Added a new command noveler.chooseMatchAtCursor with a Markdown editor context-menu entry.
Introduced a unified selection service MatchSelectionService to:
manually choose either a character-name match or a sensitive-word match at cursor,
apply changes only to the current conflict position,
remove matches at the current position (or conflict range).
Upgraded character matching to AhoCorasick, and integrated overlap resolution + manual-selection filtering in NovelHighlightProvider.updateHighlights().
Upgraded sensitive-word matching to AhoCorasickLevel, with manual-selection-aware filtering in SensitiveWordService.detect().
Added singleton access SensitiveWordDiagnosticProvider.getInstance() so diagnostics can be refreshed immediately after command execution.
Problems solved
Resolves unresolved conflicts at the same cursor location (cross-type conflicts and overlapping long/short matches).
Provides position-scoped, explicit, and reversible manual override behavior.
Improves multi-pattern matching scalability/performance by adopting the AC automaton.