### PR TITLE
feat: 支持自定义章节/人物/草稿/参考资料目录名

### DIFF
--- a/src/commands/createChapter.ts
+++ b/src/commands/createChapter.ts
@@ -11,7 +11,7 @@ import { validateChapterName } from '../utils/inputValidator';
 import { handleError, handleSuccess } from '../utils/errorHandler';
 import { ConfigService } from '../services/configService';
 import { VolumeService } from '../services/volumeService';
-import { CHAPTERS_FOLDER, CHAPTER_NUMBER_PADDING, VOLUME_TYPE_NAMES, SIDEBAR_REFRESH_DELAY } from '../constants';
+import { CHAPTER_NUMBER_PADDING, VOLUME_TYPE_NAMES, SIDEBAR_REFRESH_DELAY } from '../constants';
 import { Logger } from '../utils/logger';
 import { VolumeInfo } from '../types/volume';
 
@@ -160,7 +160,7 @@ export async function createChapter(chapterName: string): Promise<void> {
             }
 
             // 打开 chapters 目录
-            const chaptersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, CHAPTERS_FOLDER);
+            const chaptersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getChaptersFolder());
             try {
                 await vscode.workspace.fs.stat(chaptersFolderUri);
             } catch {
@@ -209,7 +209,7 @@ export async function createChapter(chapterName: string): Promise<void> {
         // 扁平模式：直接在 chapters/ 目录下创建
         Logger.info('使用扁平结构创建章节');
 
-        targetFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, CHAPTERS_FOLDER);
+        targetFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getChaptersFolder());
 
         // 确保 chapters 目录存在
         try {

--- a/src/commands/createCharacter.ts
+++ b/src/commands/createCharacter.ts
@@ -7,6 +7,7 @@ import { loadTemplates } from '../utils/templateLoader';
 import { formatDateTime } from '../utils/dateFormatter';
 import { validateCharacterName } from '../utils/inputValidator';
 import { handleError, handleSuccess } from '../utils/errorHandler';
+import { ConfigService } from '../services/configService';
 import { CHARACTERS_FOLDER } from '../constants';
 
 /**
@@ -37,7 +38,7 @@ export async function createCharacter(characterName: string): Promise<void> {
         }
     }
 
-    const charactersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, CHARACTERS_FOLDER);
+    const charactersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getCharactersFolder());
 
     // 确保 characters 目录存在
     try {

--- a/src/commands/initProject.ts
+++ b/src/commands/initProject.ts
@@ -5,8 +5,9 @@
 import * as vscode from 'vscode';
 import { loadTemplates } from '../utils/templateLoader';
 import { formatDateTime } from '../utils/dateFormatter';
+import { ConfigService } from "../services/configService";
 import { handleError, handleSuccess } from '../utils/errorHandler';
-import { PROJECT_DIRECTORIES, CONFIG_FILE_NAME, DEFAULT_CONFIG_TEMPLATE_PATH } from '../constants';
+import { CONFIG_FILE_NAME, DEFAULT_CONFIG_TEMPLATE_PATH } from '../constants';
 import { Logger } from '../utils/logger';
 
 /**
@@ -102,7 +103,7 @@ export async function initProject(context: vscode.ExtensionContext): Promise<voi
 
     try {
         // 创建目录结构
-        for (const dir of PROJECT_DIRECTORIES) {
+        for (const dir of ConfigService.getInstance().getProjectDirectories()) {
             const dirUri = vscode.Uri.joinPath(workspaceFolder.uri, dir);
             try {
                 await vscode.workspace.fs.stat(dirUri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import { PARAGRAPH_INDENT, VOLUME_TYPE_NAMES } from './constants';
 import { MigrationService } from './services/migrationService';
 import { Debouncer } from './utils/debouncer';
 import { handleError, ErrorSeverity } from './utils/errorHandler';
-import { WORD_COUNT_DEBOUNCE_DELAY, HIGHLIGHT_DEBOUNCE_DELAY, README_UPDATE_DEBOUNCE_DELAY, CHAPTERS_FOLDER, CONFIG_FILE_NAME } from './constants';
+import { WORD_COUNT_DEBOUNCE_DELAY, HIGHLIGHT_DEBOUNCE_DELAY, README_UPDATE_DEBOUNCE_DELAY, CONFIG_FILE_NAME } from './constants';
 import { Logger, LogLevel } from './utils/logger';
 import { DoubtMarkService } from './services/doubtMarkService';
 import { DoubtMarkDecorationProvider } from './providers/doubtMarkDecorationProvider';
@@ -343,7 +343,7 @@ function registerFileSystemWatchers(
     }
 
     // 监听所有章节文件变化（**/*.md 同时覆盖扁平结构和嵌套分卷结构）
-    const chaptersPattern = new vscode.RelativePattern(workspaceFolder, `${CHAPTERS_FOLDER}/**/*.md`);
+    const chaptersPattern = new vscode.RelativePattern(workspaceFolder, `${ConfigService.getInstance().getChaptersFolder()}/**/*.md`);
     const chaptersWatcher = vscode.workspace.createFileSystemWatcher(chaptersPattern);
     chaptersWatcher.onDidCreate(() => {
         novelerViewProvider.refresh();
@@ -555,7 +555,7 @@ function handleLineBreak(event: vscode.TextDocumentChangeEvent) {
 
     const filePath = event.document.uri.fsPath;
     const normalizedPath = filePath.replace(/\\/g, '/');
-    if (!normalizedPath.includes(`/${CHAPTERS_FOLDER}/`)) {
+    if (!normalizedPath.includes(`/${ConfigService.getInstance().getChaptersFolder()}/`)) {
         return;
     }
 

--- a/src/providers/highlightProvider.ts
+++ b/src/providers/highlightProvider.ts
@@ -92,7 +92,7 @@ export class NovelHighlightProvider {
             return;
         }
 
-        const charactersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, CHARACTERS_FOLDER);
+        const charactersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getCharactersFolder());
 
         try {
             // 检查目录是否存在
@@ -144,7 +144,7 @@ export class NovelHighlightProvider {
             return;
         }
 
-        const pattern = new vscode.RelativePattern(workspaceFolder, `${CHARACTERS_FOLDER}/*.md`);
+        const pattern = new vscode.RelativePattern(workspaceFolder, `${ConfigService.getInstance().getCharactersFolder()}/*.md`);
         this.characterFolderWatcher = vscode.workspace.createFileSystemWatcher(pattern);
 
         // 文件创建、修改、删除时重新加载人物名称并刷新高亮

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
 import { handleError, ErrorSeverity } from '../utils/errorHandler';
-import { CONFIG_FILE_NAME, DEFAULT_TARGET_WORDS } from '../constants';
+import { CONFIG_FILE_NAME, DEFAULT_TARGET_WORDS, CHAPTERS_FOLDER, CHARACTERS_FOLDER, DRAFTS_FOLDER, REFERENCES_FOLDER } from '../constants';
 import * as jsoncParser from 'jsonc-parser';
 import { validateConfig, fixConfig } from '../utils/configValidator';
 import { Logger } from '../utils/logger';
 import { SensitiveWordConfig } from '../types/sensitiveWord';
 import { VolumesConfig } from '../types/volume';
+import { DirectoriesConfig } from '../types/directories';
 import type { FocusModeConfig, TypingSoundType, TypewriterPosition } from './focusModeService';
 
 /**
@@ -79,6 +80,8 @@ export interface NovelConfig {
     sensitiveWords?: SensitiveWordConfig;
     /** 分卷功能配置 */
     volumes?: VolumesConfig;
+    /** 目录配置 */
+    directories?: DirectoriesConfig;
     /** 护眼模式配置 */
     eyeCareMode?: {
         /** 是否启用 */
@@ -476,6 +479,60 @@ export class ConfigService {
     public isVolumesEnabled(): boolean {
         const volumes = this.config.volumes;
         return volumes?.enabled === true && volumes?.folderStructure === 'nested';
+    }
+
+
+    /**
+     * 获取目录配置
+     * @returns 目录配置对象
+     */
+    public getDirectoriesConfig(): DirectoriesConfig {
+        return this.config.directories || {};
+    }
+
+    /**
+     * 获取章节目录名
+     * @returns 章节目录名，默认为 "chapters"
+     */
+    public getChaptersFolder(): string {
+        return this.config.directories?.chapters || CHAPTERS_FOLDER;
+    }
+
+    /**
+     * 获取人物目录名
+     * @returns 人物目录名，默认为 "characters"
+     */
+    public getCharactersFolder(): string {
+        return this.config.directories?.characters || CHARACTERS_FOLDER;
+    }
+
+    /**
+     * 获取草稿目录名
+     * @returns 草稿目录名，默认为 "drafts"
+     */
+    public getDraftsFolder(): string {
+        return this.config.directories?.drafts || DRAFTS_FOLDER;
+    }
+
+    /**
+     * 获取参考资料目录名
+     * @returns 参考资料目录名，默认为 "references"
+     */
+    public getReferencesFolder(): string {
+        return this.config.directories?.references || REFERENCES_FOLDER;
+    }
+
+    /**
+     * 获取项目目录列表（用于初始化项目等场景）
+     * @returns 目录名数组
+     */
+    public getProjectDirectories(): string[] {
+        return [
+            this.getChaptersFolder(),
+            this.getCharactersFolder(),
+            this.getDraftsFolder(),
+            this.getReferencesFolder()
+        ];
     }
 
     /**

--- a/src/services/projectStatsService.ts
+++ b/src/services/projectStatsService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import { CHAPTERS_FOLDER, CHARACTERS_FOLDER, COMPLETED_STATUS } from '../constants';
+import { ConfigService } from "./configService";
+import { COMPLETED_STATUS } from '../constants';
 import { WordCountService } from './wordCountService';
 import { handleError, ErrorSeverity } from '../utils/errorHandler';
 import { parseFrontMatter } from '../utils/frontMatterParser';
@@ -101,7 +102,7 @@ export class ProjectStatsService {
         workspaceFolder: vscode.WorkspaceFolder,
         stats: ProjectStats
     ): Promise<void> {
-        const chaptersPath = vscode.Uri.joinPath(workspaceFolder.uri, CHAPTERS_FOLDER);
+        const chaptersPath = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getChaptersFolder());
 
         try {
             // 递归扫描所有 .md 文件（支持扁平结构和分卷嵌套结构）
@@ -171,7 +172,7 @@ export class ProjectStatsService {
         workspaceFolder: vscode.WorkspaceFolder,
         stats: ProjectStats
     ): Promise<void> {
-        const charactersPath = vscode.Uri.joinPath(workspaceFolder.uri, CHARACTERS_FOLDER);
+        const charactersPath = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getCharactersFolder());
 
         try {
             // 递归扫描所有 .md 文件

--- a/src/types/directories.ts
+++ b/src/types/directories.ts
@@ -1,0 +1,14 @@
+/**
+ * 目录配置接口
+ * 允许用户自定义小说项目的目录名称
+ */
+export interface DirectoriesConfig {
+    /** 章节目录名，默认为 "chapters" */
+    chapters?: string;
+    /** 人物目录名，默认为 "characters" */
+    characters?: string;
+    /** 草稿目录名，默认为 "drafts" */
+    drafts?: string;
+    /** 参考资料目录名，默认为 "references" */
+    references?: string;
+}

--- a/src/utils/readmeUpdater.ts
+++ b/src/utils/readmeUpdater.ts
@@ -3,7 +3,7 @@ import { parseFrontMatter } from './frontMatterParser';
 import { handleError, handleSuccess, ErrorSeverity } from './errorHandler';
 import { ConfigService } from '../services/configService';
 import { VolumeService } from '../services/volumeService';
-import { CHAPTERS_FOLDER, CHARACTERS_FOLDER, STATUS_EMOJI_MAP } from '../constants';
+import { STATUS_EMOJI_MAP } from '../constants';
 import { Logger } from './logger';
 import { getStatusDisplayName } from './statusHelper';
 
@@ -57,7 +57,7 @@ export async function scanChapters(): Promise<ProjectStats> {
     const configService = ConfigService.getInstance();
     const volumesEnabled = configService.isVolumesEnabled();
 
-    const chaptersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, CHAPTERS_FOLDER);
+    const chaptersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getChaptersFolder());
     const chapters: ChapterInfo[] = [];
     let totalWords = 0;
     let completedChapters = 0;
@@ -80,7 +80,7 @@ export async function scanChapters(): Promise<ProjectStats> {
                     try {
                         const fileUri = vscode.Uri.joinPath(
                             workspaceFolder.uri,
-                            CHAPTERS_FOLDER,
+                            ConfigService.getInstance().getChaptersFolder(),
                             volume.folderName,
                             chapterFile
                         );
@@ -236,7 +236,7 @@ export async function scanCharacters(): Promise<CharacterInfo[]> {
         return [];
     }
 
-    const charactersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, CHARACTERS_FOLDER);
+    const charactersFolderUri = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getCharactersFolder());
     const characters: CharacterInfo[] = [];
 
     try {

--- a/src/views/nodes/chapterNodes.ts
+++ b/src/views/nodes/chapterNodes.ts
@@ -8,7 +8,7 @@ import { VolumeService } from '../../services/volumeService';
 import { ConfigService } from '../../services/configService';
 import { WordCountService } from '../../services/wordCountService';
 import { extractChapterFrontMatter, getContentWithoutFrontMatter } from '../../utils/frontMatterHelper';
-import { CHAPTERS_FOLDER, VOLUME_TYPE_NAMES, VOLUME_STATUS_NAMES } from '../../constants';
+import { VOLUME_TYPE_NAMES, VOLUME_STATUS_NAMES } from '../../constants';
 import { VolumeInfo } from '../../types/volume';
 import { convertToChineseNumber } from '../../utils/chineseNumber';
 import { convertToRomanNumber } from '../../utils/volumeHelper';
@@ -215,7 +215,7 @@ export class ChapterNodesProvider {
             return [];
         }
 
-        const folderPath = vscode.Uri.joinPath(workspaceFolder.uri, CHAPTERS_FOLDER);
+        const folderPath = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getChaptersFolder());
 
         try {
             const files = await vscode.workspace.fs.readDirectory(folderPath);

--- a/src/views/nodes/characterNodes.ts
+++ b/src/views/nodes/characterNodes.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import { NovelerTreeItem, NodeType } from '../novelerViewProvider';
 import { extractFrontMatter } from '../../utils/frontMatterHelper';
+import { ConfigService } from '../../services/configService';
 import { CHARACTERS_FOLDER } from '../../constants';
 import { Logger } from '../../utils/logger';
 
@@ -17,7 +18,7 @@ export class CharacterNodesProvider {
             return [];
         }
 
-        const folderPath = vscode.Uri.joinPath(workspaceFolder.uri, CHARACTERS_FOLDER);
+        const folderPath = vscode.Uri.joinPath(workspaceFolder.uri, ConfigService.getInstance().getCharactersFolder());
 
         try {
             const files = await vscode.workspace.fs.readDirectory(folderPath);

--- a/src/views/nodes/outlineNodes.ts
+++ b/src/views/nodes/outlineNodes.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import { NovelerTreeItem, NodeType } from '../novelerViewProvider';
 import { extractFrontMatter } from '../../utils/frontMatterHelper';
+import { ConfigService } from '../../services/configService';
 import { DRAFTS_FOLDER, REFERENCES_FOLDER } from '../../constants';
 import { Logger } from '../../utils/logger';
 

--- a/templates/default-config.jsonc
+++ b/templates/default-config.jsonc
@@ -132,6 +132,20 @@
       "chapterNumbering": "volume"
     },
 
+    // ==================== 目录配置 ====================
+    // 自定义小说项目的目录名称
+    // 如果不设置，将使用默认值
+    "directories": {
+      // 章节目录名，默认为 "chapters"
+      // "chapters": "chapters",
+      // 人物目录名，默认为 "characters"
+      // "characters": "characters",
+      // 草稿目录名，默认为 "drafts"
+      // "drafts": "drafts",
+      // 参考资料目录名，默认为 "references"
+      // "references": "references"
+    },
+
     // ==================== 护眼模式 ====================
     // 使用护眼主题保护视力，仅在当前项目生效
     "eyeCareMode": {


### PR DESCRIPTION
新增 directories 配置项，允许用户自定义小说项目的目录名称。

功能变更:
- 新增 DirectoriesConfig 类型定义 (src/types/directories.ts)
- NovelConfig 新增 directories 字段，包含 chapters/characters/drafts/references 四个子项
- ConfigService 新增 getChaptersFolder() / getCharactersFolder() / getDraftsFolder() / getReferencesFolder() / getProjectDirectories() 方法
- 所有使用硬编码目录名的位置改为调用 ConfigService 方法获取
- 配置模板中新增 directories 配置节（注释状态，不设置时使用默认值）

修复:
- 批量替换多处硬编码的 CHAPTERS_FOLDER / CHARACTERS_FOLDER / DRAFTS_FOLDER / REFERENCES_FOLDER 引用
- 支持多级目录路径（如 "knowledge/abc/characters"）